### PR TITLE
Add Mailboxes feature and motion

### DIFF
--- a/Reply/app/src/main/java/com/materialstudies/reply/data/Email.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/data/Email.kt
@@ -17,6 +17,7 @@
 package com.materialstudies.reply.data
 
 import androidx.recyclerview.widget.DiffUtil
+import com.materialstudies.reply.ui.home.Mailbox
 
 /**
  * A simple data class to represent an Email.
@@ -29,7 +30,8 @@ data class Email(
     val body: String = "",
     val attachments: List<EmailAttachment> = emptyList(),
     var isImportant: Boolean = false,
-    var isStarred: Boolean = false
+    var isStarred: Boolean = false,
+    var mailbox: Mailbox = Mailbox.INBOX
 ) {
     val senderPreview: String = "${sender.fullName} - 4 hrs ago"
     val hasBody: Boolean = body.isNotBlank()

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -223,7 +223,7 @@ class MainActivity : AppCompatActivity(),
     }
 
     override fun onNavMenuItemClicked(item: NavigationModelItem.NavMenuItem) {
-        // Swap the list of emails showing
+        // Swap the list of emails for the given mailbox
         navigateToHome(item)
     }
 

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
 import com.google.android.material.transition.Hold
+import com.google.android.material.transition.MaterialFadeThrough
 import com.google.android.material.transition.MaterialSharedAxis
 import com.materialstudies.reply.R
 import com.materialstudies.reply.databinding.ActivityMainBinding
@@ -223,7 +224,7 @@ class MainActivity : AppCompatActivity(),
 
     override fun onNavMenuItemClicked(item: NavigationModelItem.NavMenuItem) {
         // Swap the list of emails showing
-        navigateToMailbox(item)
+        navigateToHome(item)
     }
 
     override fun onNavEmailFolderClicked(folder: NavigationModelItem.NavEmailFolder) {
@@ -247,8 +248,13 @@ class MainActivity : AppCompatActivity(),
         }.show(supportFragmentManager, null)
     }
 
-    private fun navigateToMailbox(item: NavigationModelItem.NavMenuItem) {
+    private fun navigateToHome(item: NavigationModelItem.NavMenuItem) {
         binding.bottomAppBarTitle.text = getString(item.titleRes)
+        supportFragmentManager.currentNavigationFragment?.setOutgoingTransitions(
+            exitTransition = MaterialFadeThrough().apply {
+                duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+            }
+        )
         findNavController(R.id.nav_host_fragment)
             .navigate(HomeFragmentDirections.actionHomeFragmentToHomeFragment(item.mailbox))
     }
@@ -265,8 +271,12 @@ class MainActivity : AppCompatActivity(),
 
     private fun navigateToSearch() {
         supportFragmentManager.currentNavigationFragment?.setOutgoingTransitions(
-                reenterTransition = MaterialSharedAxis(MaterialSharedAxis.Z, false),
-                exitTransition = MaterialSharedAxis(MaterialSharedAxis.Z, true)
+                reenterTransition = MaterialSharedAxis(MaterialSharedAxis.Z, false).apply {
+                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+                },
+                exitTransition = MaterialSharedAxis(MaterialSharedAxis.Z, true).apply {
+                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+                }
         )
         findNavController(R.id.nav_host_fragment)
                 .navigate(SearchFragmentDirections.actionGlobalSearchFragment())

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -34,6 +34,7 @@ import com.materialstudies.reply.R
 import com.materialstudies.reply.databinding.ActivityMainBinding
 import com.materialstudies.reply.ui.compose.ComposeFragmentDirections
 import com.materialstudies.reply.ui.email.EmailFragmentArgs
+import com.materialstudies.reply.ui.home.HomeFragmentDirections
 import com.materialstudies.reply.ui.nav.AlphaSlideAction
 import com.materialstudies.reply.ui.nav.BottomNavDrawerFragment
 import com.materialstudies.reply.ui.nav.ChangeSettingsMenuStateAction
@@ -222,8 +223,7 @@ class MainActivity : AppCompatActivity(),
 
     override fun onNavMenuItemClicked(item: NavigationModelItem.NavMenuItem) {
         // Swap the list of emails showing
-        binding.bottomAppBarTitle.text = getString(item.titleRes)
-        // TODO:
+        navigateToMailbox(item)
     }
 
     override fun onNavEmailFolderClicked(folder: NavigationModelItem.NavEmailFolder) {
@@ -245,6 +245,12 @@ class MainActivity : AppCompatActivity(),
         MenuBottomSheetDialogFragment(R.menu.dark_theme_bottom_sheet_menu) {
             onDarkThemeMenuItemSelected(it.itemId)
         }.show(supportFragmentManager, null)
+    }
+
+    private fun navigateToMailbox(item: NavigationModelItem.NavMenuItem) {
+        binding.bottomAppBarTitle.text = getString(item.titleRes)
+        findNavController(R.id.nav_host_fragment)
+            .navigate(HomeFragmentDirections.actionHomeFragmentToHomeFragment(item.mailbox))
     }
 
     private fun navigateToCompose() {

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -39,6 +39,8 @@ import com.materialstudies.reply.ui.nav.BottomNavDrawerFragment
 import com.materialstudies.reply.ui.nav.ChangeSettingsMenuStateAction
 import com.materialstudies.reply.ui.nav.HalfClockwiseRotateSlideAction
 import com.materialstudies.reply.ui.nav.HalfCounterClockwiseRotateSlideAction
+import com.materialstudies.reply.ui.nav.NavigationAdapter
+import com.materialstudies.reply.ui.nav.NavigationModelItem
 import com.materialstudies.reply.ui.nav.ShowHideFabStateAction
 import com.materialstudies.reply.ui.search.SearchFragmentDirections
 import com.materialstudies.reply.util.contentView
@@ -47,8 +49,9 @@ import com.materialstudies.reply.util.setOutgoingTransitions
 import kotlin.LazyThreadSafetyMode.NONE
 
 class MainActivity : AppCompatActivity(),
-    Toolbar.OnMenuItemClickListener,
-    NavController.OnDestinationChangedListener {
+                     Toolbar.OnMenuItemClickListener,
+                     NavController.OnDestinationChangedListener,
+                     NavigationAdapter.NavigationAdapterListener {
 
     private val binding: ActivityMainBinding by contentView(R.layout.activity_main)
     private val bottomNavDrawer: BottomNavDrawerFragment by lazy(NONE) {
@@ -97,6 +100,7 @@ class MainActivity : AppCompatActivity(),
             })
 
             addOnSandwichSlideAction(HalfCounterClockwiseRotateSlideAction(binding.bottomAppBarChevron))
+            addNavigationListener(this@MainActivity)
         }
 
         // Set up the BottomAppBar menu
@@ -216,6 +220,16 @@ class MainActivity : AppCompatActivity(),
         }
     }
 
+    override fun onNavMenuItemClicked(item: NavigationModelItem.NavMenuItem) {
+        // Swap the list of emails showing
+        binding.bottomAppBarTitle.text = getString(item.titleRes)
+        // TODO:
+    }
+
+    override fun onNavEmailFolderClicked(folder: NavigationModelItem.NavEmailFolder) {
+        // Do nothing
+    }
+
     override fun onMenuItemClick(item: MenuItem?): Boolean {
         when (item?.itemId) {
             R.id.menu_settings -> {
@@ -267,4 +281,5 @@ class MainActivity : AppCompatActivity(),
         delegate.localNightMode = nightMode
         return true
     }
+
 }

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -22,6 +22,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
 import androidx.annotation.MenuRes
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
@@ -35,7 +36,9 @@ import com.materialstudies.reply.R
 import com.materialstudies.reply.databinding.ActivityMainBinding
 import com.materialstudies.reply.ui.compose.ComposeFragmentDirections
 import com.materialstudies.reply.ui.email.EmailFragmentArgs
+import com.materialstudies.reply.ui.home.HomeFragmentArgs
 import com.materialstudies.reply.ui.home.HomeFragmentDirections
+import com.materialstudies.reply.ui.home.Mailbox
 import com.materialstudies.reply.ui.nav.AlphaSlideAction
 import com.materialstudies.reply.ui.nav.BottomNavDrawerFragment
 import com.materialstudies.reply.ui.nav.ChangeSettingsMenuStateAction
@@ -224,7 +227,7 @@ class MainActivity : AppCompatActivity(),
 
     override fun onNavMenuItemClicked(item: NavigationModelItem.NavMenuItem) {
         // Swap the list of emails for the given mailbox
-        navigateToHome(item)
+        navigateToHome(item.titleRes, item.mailbox)
     }
 
     override fun onNavEmailFolderClicked(folder: NavigationModelItem.NavEmailFolder) {
@@ -248,38 +251,38 @@ class MainActivity : AppCompatActivity(),
         }.show(supportFragmentManager, null)
     }
 
-    private fun navigateToHome(item: NavigationModelItem.NavMenuItem) {
-        binding.bottomAppBarTitle.text = getString(item.titleRes)
+    fun navigateToHome(@StringRes titleRes: Int, mailbox: Mailbox) {
+        binding.bottomAppBarTitle.text = getString(titleRes)
         supportFragmentManager.currentNavigationFragment?.setOutgoingTransitions(
             exitTransition = MaterialFadeThrough().apply {
                 duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
             }
         )
         findNavController(R.id.nav_host_fragment)
-            .navigate(HomeFragmentDirections.actionHomeFragmentToHomeFragment(item.mailbox))
+            .navigate(HomeFragmentDirections.actionHomeFragmentToHomeFragment(mailbox))
     }
 
     private fun navigateToCompose() {
         supportFragmentManager.currentNavigationFragment?.setOutgoingTransitions(
-                exitTransition = Hold().apply {
-                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
-                }
+            exitTransition = Hold().apply {
+                duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+            }
         )
         findNavController(R.id.nav_host_fragment)
-                .navigate(ComposeFragmentDirections.actionGlobalComposeFragment(currentEmailId))
+            .navigate(ComposeFragmentDirections.actionGlobalComposeFragment(currentEmailId))
     }
 
     private fun navigateToSearch() {
         supportFragmentManager.currentNavigationFragment?.setOutgoingTransitions(
-                reenterTransition = MaterialSharedAxis(MaterialSharedAxis.Z, false).apply {
-                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
-                },
-                exitTransition = MaterialSharedAxis(MaterialSharedAxis.Z, true).apply {
-                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
-                }
+            reenterTransition = MaterialSharedAxis(MaterialSharedAxis.Z, false).apply {
+                duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+            },
+            exitTransition = MaterialSharedAxis(MaterialSharedAxis.Z, true).apply {
+                duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+            }
         )
         findNavController(R.id.nav_host_fragment)
-                .navigate(SearchFragmentDirections.actionGlobalSearchFragment())
+            .navigate(SearchFragmentDirections.actionGlobalSearchFragment())
     }
 
     /**

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
@@ -66,7 +66,7 @@ class HomeFragment : Fragment(), EmailAdapter.EmailAdapterListener {
         }
         binding.recyclerView.adapter = emailAdapter
 
-        EmailStore.emails.observe(this) {
+        EmailStore.emails.observe(viewLifecycleOwner) {
             emailAdapter.submitList(it)
         }
     }
@@ -86,7 +86,7 @@ class HomeFragment : Fragment(), EmailAdapter.EmailAdapterListener {
         MenuBottomSheetDialogFragment(R.menu.email_bottom_sheet_menu) {
             // Do nothing.
             true
-        }.show(requireFragmentManager(), null)
+        }.show(parentFragmentManager, null)
 
         return true
     }

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
@@ -28,6 +28,8 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.ItemTouchHelper
 import com.google.android.material.transition.Hold
+import com.google.android.material.transition.MaterialFade
+import com.google.android.material.transition.MaterialFadeThrough
 import com.materialstudies.reply.R
 import com.materialstudies.reply.data.Email
 import com.materialstudies.reply.data.EmailStore
@@ -45,6 +47,13 @@ class HomeFragment : Fragment(), EmailAdapter.EmailAdapterListener {
     private lateinit var binding: FragmentHomeBinding
 
     private val emailAdapter = EmailAdapter(this)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enterTransition = MaterialFadeThrough().apply {
+            duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
@@ -25,6 +25,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.ItemTouchHelper
 import com.google.android.material.transition.Hold
 import com.materialstudies.reply.R
@@ -38,6 +39,8 @@ import com.materialstudies.reply.util.setOutgoingTransitions
  * A [Fragment] that displays a list of emails.
  */
 class HomeFragment : Fragment(), EmailAdapter.EmailAdapterListener {
+
+    private val args: HomeFragmentArgs by navArgs()
 
     private lateinit var binding: FragmentHomeBinding
 
@@ -66,7 +69,7 @@ class HomeFragment : Fragment(), EmailAdapter.EmailAdapterListener {
         }
         binding.recyclerView.adapter = emailAdapter
 
-        EmailStore.emails.observe(viewLifecycleOwner) {
+        EmailStore.getEmails(args.listType).observe(viewLifecycleOwner) {
             emailAdapter.submitList(it)
         }
     }

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
@@ -78,7 +78,7 @@ class HomeFragment : Fragment(), EmailAdapter.EmailAdapterListener {
         }
         binding.recyclerView.adapter = emailAdapter
 
-        EmailStore.getEmails(args.listType).observe(viewLifecycleOwner) {
+        EmailStore.getEmails(args.mailbox).observe(viewLifecycleOwner) {
             emailAdapter.submitList(it)
         }
     }

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/home/Mailbox.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/home/Mailbox.kt
@@ -1,0 +1,8 @@
+package com.materialstudies.reply.ui.home
+
+/**
+ * An enumeration of mailboxes into which emails can be placed.
+ */
+enum class Mailbox {
+  INBOX, STARRED, SENT, TRASH, SPAM, DRAFTS
+}

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/nav/BottomNavDrawerFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/nav/BottomNavDrawerFragment.kt
@@ -277,7 +277,8 @@ class BottomNavDrawerFragment :
     }
 
     override fun onNavMenuItemClicked(item: NavigationModelItem.NavMenuItem) {
-        if (NavigationModel.setNavigationMenuItemChecked(item.id)) close()
+        NavigationModel.setNavigationMenuItemChecked(item.id)
+        close()
         navigationListeners.forEach { it.onNavMenuItemClicked(item) }
     }
 

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/nav/NavigationModel.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/nav/NavigationModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.materialstudies.reply.R
 import com.materialstudies.reply.data.EmailStore
+import com.materialstudies.reply.ui.home.Mailbox
 
 /**
  * A class which maintains and generates a navigation list to be displayed by [NavigationAdapter].
@@ -31,37 +32,43 @@ object NavigationModel {
             id = 0,
             icon = R.drawable.ic_twotone_inbox,
             titleRes = R.string.navigation_inbox,
-            checked = false
+            checked = false,
+            mailbox = Mailbox.INBOX
         ),
         NavigationModelItem.NavMenuItem(
             id = 1,
             icon = R.drawable.ic_twotone_stars,
             titleRes = R.string.navigation_starred,
-            checked = false
+            checked = false,
+            mailbox = Mailbox.STARRED
         ),
         NavigationModelItem.NavMenuItem(
             id = 2,
             icon = R.drawable.ic_twotone_send,
             titleRes = R.string.navigation_sent,
-            checked = false
+            checked = false,
+            mailbox = Mailbox.SENT
         ),
         NavigationModelItem.NavMenuItem(
             id = 3,
             icon = R.drawable.ic_twotone_delete,
             titleRes = R.string.navigation_trash,
-            checked = false
+            checked = false,
+            mailbox = Mailbox.TRASH
         ),
         NavigationModelItem.NavMenuItem(
             id = 4,
             icon = R.drawable.ic_twotone_error,
             titleRes = R.string.navigation_spam,
-            checked = false
+            checked = false,
+            mailbox = Mailbox.SPAM
         ),
         NavigationModelItem.NavMenuItem(
             id = 5,
             icon = R.drawable.ic_twotone_drafts,
             titleRes = R.string.navigation_drafts,
-            checked = false
+            checked = false,
+            mailbox = Mailbox.DRAFTS
         )
     )
 

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/nav/NavigationModelItem.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/nav/NavigationModelItem.kt
@@ -39,7 +39,7 @@ sealed class NavigationModelItem {
 
     /**
      * A class which is used to show a section divider (a subtitle and underline) between
-     * sections of differen NavigationModelItem types.
+     * sections of different NavigationModelItem types.
      */
     data class NavDivider(val title: String) : NavigationModelItem()
 

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/nav/NavigationModelItem.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/nav/NavigationModelItem.kt
@@ -21,6 +21,7 @@ import androidx.annotation.StringRes
 import androidx.recyclerview.widget.DiffUtil
 import com.materialstudies.reply.data.EmailFolder
 import com.materialstudies.reply.data.EmailFolderDiff
+import com.materialstudies.reply.ui.home.Mailbox
 
 /**
  * A sealed class which encapsulates all objects [NavigationAdapter] is able to display.
@@ -34,6 +35,7 @@ sealed class NavigationModelItem {
         val id: Int,
         @DrawableRes val icon: Int,
         @StringRes val titleRes: Int,
+        val mailbox: Mailbox,
         var checked: Boolean
     ) : NavigationModelItem()
 

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/search/SearchFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/search/SearchFragment.kt
@@ -42,8 +42,12 @@ class SearchFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        enterTransition = MaterialSharedAxis(MaterialSharedAxis.Z, true)
-        returnTransition = MaterialSharedAxis(MaterialSharedAxis.Z, false)
+        enterTransition = MaterialSharedAxis(MaterialSharedAxis.Z, true).apply {
+            duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+        }
+        returnTransition = MaterialSharedAxis(MaterialSharedAxis.Z, false).apply {
+            duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+        }
     }
 
     override fun onCreateView(

--- a/Reply/app/src/main/res/navigation/navigation_graph.xml
+++ b/Reply/app/src/main/res/navigation/navigation_graph.xml
@@ -19,10 +19,18 @@
     <fragment
         android:id="@+id/homeFragment"
         android:name="com.materialstudies.reply.ui.home.HomeFragment"
-        android:label="HomeFragment" >
+        android:label="HomeFragment">
+        <argument
+            android:name="listType"
+            app:argType="com.materialstudies.reply.ui.home.EmailListType"
+            android:defaultValue="INBOX"/>
         <action
             android:id="@+id/action_homeFragment_to_emailFragment"
             app:destination="@id/emailFragment" />
+        <action
+            android:id="@+id/action_homeFragment_to_homeFragment"
+            app:destination="@+id/homeFragment"
+            app:launchSingleTop="true"/>
     </fragment>
     <fragment
         android:id="@+id/emailFragment"

--- a/Reply/app/src/main/res/navigation/navigation_graph.xml
+++ b/Reply/app/src/main/res/navigation/navigation_graph.xml
@@ -22,7 +22,7 @@
         android:label="HomeFragment">
         <argument
             android:name="listType"
-            app:argType="com.materialstudies.reply.ui.home.EmailListType"
+            app:argType="com.materialstudies.reply.ui.home.Mailbox"
             android:defaultValue="INBOX"/>
         <action
             android:id="@+id/action_homeFragment_to_emailFragment"

--- a/Reply/app/src/main/res/navigation/navigation_graph.xml
+++ b/Reply/app/src/main/res/navigation/navigation_graph.xml
@@ -23,7 +23,7 @@
         <argument
             android:name="mailbox"
             app:argType="com.materialstudies.reply.ui.home.Mailbox"
-            android:defaultValue="INBOX"/>
+            android:defaultValue="INBOX" />
         <action
             android:id="@+id/action_homeFragment_to_emailFragment"
             app:destination="@id/emailFragment" />

--- a/Reply/app/src/main/res/navigation/navigation_graph.xml
+++ b/Reply/app/src/main/res/navigation/navigation_graph.xml
@@ -21,7 +21,7 @@
         android:name="com.materialstudies.reply.ui.home.HomeFragment"
         android:label="HomeFragment">
         <argument
-            android:name="listType"
+            android:name="mailbox"
             app:argType="com.materialstudies.reply.ui.home.Mailbox"
             android:defaultValue="INBOX"/>
         <action


### PR DESCRIPTION
* Add a `Mailbox` enum to bucket emails into boxes and show different emails depending on the navigation destinations selected in the bottom navigation drawer
* Add `MaterialFadeThrough` transitions to outgoing and incoming `HomeFragment`s when swapping mailboxes 
* Update `SearchFragment` transitions to use `R.integer.reply_motion_default_large` duration

![fade_through_gif](https://user-images.githubusercontent.com/7459254/84393573-c16ace80-abc9-11ea-9303-a5278852eda3.gif)

