### PR TITLE
[Reply] Add elevation scale transition to exiting and reentering screens during Container Transform

### DIFF
--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -28,7 +28,6 @@ import androidx.appcompat.widget.Toolbar
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
-import com.google.android.material.transition.Hold
 import com.google.android.material.transition.MaterialSharedAxis
 import com.materialstudies.reply.R
 import com.materialstudies.reply.databinding.ActivityMainBinding
@@ -42,6 +41,7 @@ import com.materialstudies.reply.ui.nav.HalfCounterClockwiseRotateSlideAction
 import com.materialstudies.reply.ui.nav.ShowHideFabStateAction
 import com.materialstudies.reply.ui.search.SearchFragmentDirections
 import com.materialstudies.reply.util.contentView
+import com.materialstudies.reply.util.createMaterialElevationScale
 import com.materialstudies.reply.util.currentNavigationFragment
 import com.materialstudies.reply.util.setOutgoingTransitions
 import kotlin.LazyThreadSafetyMode.NONE
@@ -235,7 +235,10 @@ class MainActivity : AppCompatActivity(),
 
     private fun navigateToCompose() {
         supportFragmentManager.currentNavigationFragment?.setOutgoingTransitions(
-                exitTransition = Hold().apply {
+                reenterTransition = createMaterialElevationScale(true).apply {
+                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+                },
+                exitTransition = createMaterialElevationScale( false).apply {
                     duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
                 }
         )

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -235,12 +235,12 @@ class MainActivity : AppCompatActivity(),
 
     private fun navigateToCompose() {
         supportFragmentManager.currentNavigationFragment?.setOutgoingTransitions(
-                reenterTransition = createMaterialElevationScale(true).apply {
-                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
-                },
-                exitTransition = createMaterialElevationScale( false).apply {
-                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
-                }
+            reenterTransition = createMaterialElevationScale(true).apply {
+                duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+            },
+            exitTransition = createMaterialElevationScale(false).apply {
+                duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+            }
         )
         findNavController(R.id.nav_host_fragment)
                 .navigate(ComposeFragmentDirections.actionGlobalComposeFragment(currentEmailId))

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/compose/ComposeFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/compose/ComposeFragment.kt
@@ -16,6 +16,7 @@
 
 package com.materialstudies.reply.ui.compose
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -115,6 +116,7 @@ class ComposeFragment : Fragment() {
             endView = binding.emailCardView
             duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
             interpolator = requireContext().themeInterpolator(R.attr.motionInterpolatorPersistent)
+            scrimColor = Color.TRANSPARENT
         }
         returnTransition = Slide().apply {
             duration = resources.getInteger(R.integer.reply_motion_duration_medium).toLong()

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/email/EmailFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/email/EmailFragment.kt
@@ -16,6 +16,7 @@
 
 package com.materialstudies.reply.ui.email
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -24,7 +25,6 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.GridLayoutManager
-import com.google.android.material.transition.Hold
 import com.google.android.material.transition.MaterialContainerTransform
 import com.materialstudies.reply.R
 import com.materialstudies.reply.data.EmailStore
@@ -98,12 +98,14 @@ class EmailFragment : Fragment() {
             drawingViewId = R.id.nav_host_fragment
             duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
             interpolator = requireContext().themeInterpolator(R.attr.motionInterpolatorPersistent)
+            scrimColor = Color.TRANSPARENT
         }
         sharedElementReturnTransition = MaterialContainerTransform().apply {
             // Again, scope the return transition so it is added below the bottom app bar.
-            drawingViewId = R.id.recycler_view
+            drawingViewId = R.id.home_root
             duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
             interpolator = requireContext().themeInterpolator(R.attr.motionInterpolatorPersistent)
+            scrimColor = Color.TRANSPARENT
         }
     }
 

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
@@ -26,12 +26,12 @@ import androidx.lifecycle.observe
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.ItemTouchHelper
-import com.google.android.material.transition.Hold
 import com.materialstudies.reply.R
 import com.materialstudies.reply.data.Email
 import com.materialstudies.reply.data.EmailStore
 import com.materialstudies.reply.databinding.FragmentHomeBinding
 import com.materialstudies.reply.ui.MenuBottomSheetDialogFragment
+import com.materialstudies.reply.util.createMaterialElevationScale
 import com.materialstudies.reply.util.setOutgoingTransitions
 
 /**
@@ -73,7 +73,10 @@ class HomeFragment : Fragment(), EmailAdapter.EmailAdapterListener {
 
     override fun onEmailClicked(cardView: View, email: Email) {
         setOutgoingTransitions(
-                exitTransition = Hold().apply {
+                reenterTransition = createMaterialElevationScale(true).apply {
+                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+                },
+                exitTransition = createMaterialElevationScale( false).apply {
                     duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
                 }
         )

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
@@ -73,12 +73,12 @@ class HomeFragment : Fragment(), EmailAdapter.EmailAdapterListener {
 
     override fun onEmailClicked(cardView: View, email: Email) {
         setOutgoingTransitions(
-                reenterTransition = createMaterialElevationScale(true).apply {
-                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
-                },
-                exitTransition = createMaterialElevationScale( false).apply {
-                    duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
-                }
+            reenterTransition = createMaterialElevationScale(true).apply {
+                duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+            },
+            exitTransition = createMaterialElevationScale(false).apply {
+                duration = resources.getInteger(R.integer.reply_motion_default_large).toLong()
+            }
         )
         val extras = FragmentNavigatorExtras(cardView to cardView.transitionName)
         val directions = HomeFragmentDirections.actionHomeFragmentToEmailFragment(email.id)

--- a/Reply/app/src/main/java/com/materialstudies/reply/util/TransitionUtils.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/util/TransitionUtils.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.materialstudies.reply.util
+
+import androidx.transition.Transition
+import com.google.android.material.transition.FadeProvider
+import com.google.android.material.transition.MaterialSharedAxis
+import com.google.android.material.transition.ScaleProvider
+
+const val ELEVATION_START_SCALE = 0.92F
+
+/**
+ * Create an elevation scale transition that, e.g., can be used in conjunction with a container
+ * transform to give the effect that the outgoing screen is receding or advancing along the z-axis.
+ */
+fun createMaterialElevationScale(entering: Boolean): Transition {
+    return MaterialSharedAxis(MaterialSharedAxis.Z, entering).apply {
+        (primaryAnimatorProvider as ScaleProvider).incomingStartScale = ELEVATION_START_SCALE
+        secondaryAnimatorProvider = FadeProvider()
+    }
+}

--- a/Reply/app/src/main/java/com/materialstudies/reply/util/TransitionUtils.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/util/TransitionUtils.kt
@@ -21,15 +21,17 @@ import com.google.android.material.transition.FadeProvider
 import com.google.android.material.transition.MaterialSharedAxis
 import com.google.android.material.transition.ScaleProvider
 
-private const val ELEVATION_START_SCALE = 0.92F
+private const val ELEVATION_SCALE = 0.85F
 
 /**
  * Create an elevation scale transition that, e.g., can be used in conjunction with a container
  * transform to give the effect that the outgoing screen is receding or advancing along the z-axis.
  */
-fun createMaterialElevationScale(entering: Boolean): Transition {
-    return MaterialSharedAxis(MaterialSharedAxis.Z, entering).apply {
-        (primaryAnimatorProvider as ScaleProvider).incomingStartScale = ELEVATION_START_SCALE
+fun createMaterialElevationScale(forward: Boolean): Transition {
+    return MaterialSharedAxis(MaterialSharedAxis.Z, forward).apply {
+        val scaleProvider = primaryAnimatorProvider as ScaleProvider
+        scaleProvider.incomingStartScale = ELEVATION_SCALE
+        scaleProvider.outgoingEndScale = ELEVATION_SCALE
         secondaryAnimatorProvider = FadeProvider()
     }
 }

--- a/Reply/app/src/main/java/com/materialstudies/reply/util/TransitionUtils.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/util/TransitionUtils.kt
@@ -21,7 +21,7 @@ import com.google.android.material.transition.FadeProvider
 import com.google.android.material.transition.MaterialSharedAxis
 import com.google.android.material.transition.ScaleProvider
 
-const val ELEVATION_START_SCALE = 0.92F
+private const val ELEVATION_START_SCALE = 0.92F
 
 /**
  * Create an elevation scale transition that, e.g., can be used in conjunction with a container

--- a/Reply/app/src/main/java/com/materialstudies/reply/util/TransitionUtils.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/util/TransitionUtils.kt
@@ -26,6 +26,8 @@ private const val ELEVATION_SCALE = 0.85F
 /**
  * Create an elevation scale transition that, e.g., can be used in conjunction with a container
  * transform to give the effect that the outgoing screen is receding or advancing along the z-axis.
+ *
+ * TODO: remove once a MaterialElevationScale is available in the library.
  */
 fun createMaterialElevationScale(forward: Boolean): Transition {
     return MaterialSharedAxis(MaterialSharedAxis.Z, forward).apply {

--- a/Reply/app/src/main/res/layout/fragment_home.xml
+++ b/Reply/app/src/main/res/layout/fragment_home.xml
@@ -15,6 +15,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <!-- Add a wrapper layout so we can run return transitions independent of any reenter
+         transitions that may be running on the RecyclerView. -->
     <FrameLayout
         android:id="@+id/home_root"
         android:layout_width="match_parent"

--- a/Reply/app/src/main/res/layout/fragment_home.xml
+++ b/Reply/app/src/main/res/layout/fragment_home.xml
@@ -15,17 +15,24 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler_view"
+    <FrameLayout
+        android:id="@+id/home_root"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:clipToPadding="false"
-        android:paddingTop="@dimen/grid_0_25"
-        android:paddingBottom="@dimen/bottom_app_bar_height"
-        android:transitionGroup="true"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        app:paddingTopSystemWindowInsets="@{true}"
-        app:paddingBottomSystemWindowInsets="@{true}"/>
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:paddingTop="@dimen/grid_0_25"
+            android:paddingBottom="@dimen/bottom_app_bar_height"
+            android:transitionGroup="true"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            app:paddingTopSystemWindowInsets="@{true}"
+            app:paddingBottomSystemWindowInsets="@{true}"/>
+
+    </FrameLayout>
 
 </layout>


### PR DESCRIPTION
Also solves jankiness with the scrim showing outside the edges of the transforming card view and then disappearing at the end of the container transform.

![reply-elevation-scale](https://user-images.githubusercontent.com/1420597/84798876-771e8e80-afc9-11ea-954b-3a757a859867.gif)
