### PR TITLE
[Reply] Set container colors for MaterialContainerTransforms and get rid of extra FrameLayout wrapper

### DIFF
--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/compose/ComposeFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/compose/ComposeFragment.kt
@@ -34,6 +34,7 @@ import com.materialstudies.reply.data.Email
 import com.materialstudies.reply.data.EmailStore
 import com.materialstudies.reply.databinding.ComposeRecipientChipBinding
 import com.materialstudies.reply.databinding.FragmentComposeBinding
+import com.materialstudies.reply.util.themeColor
 import com.materialstudies.reply.util.themeInterpolator
 import kotlin.LazyThreadSafetyMode.NONE
 
@@ -117,6 +118,9 @@ class ComposeFragment : Fragment() {
             duration = resources.getInteger(R.integer.reply_motion_duration_large).toLong()
             interpolator = requireContext().themeInterpolator(R.attr.motionInterpolatorPersistent)
             scrimColor = Color.TRANSPARENT
+            containerColor = requireContext().themeColor(R.attr.colorSurface)
+            startContainerColor = requireContext().themeColor(R.attr.colorSecondary)
+            endContainerColor = requireContext().themeColor(R.attr.colorSurface)
         }
         returnTransition = Slide().apply {
             duration = resources.getInteger(R.integer.reply_motion_duration_medium).toLong()

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/email/EmailFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/email/EmailFragment.kt
@@ -29,6 +29,7 @@ import com.google.android.material.transition.MaterialContainerTransform
 import com.materialstudies.reply.R
 import com.materialstudies.reply.data.EmailStore
 import com.materialstudies.reply.databinding.FragmentEmailBinding
+import com.materialstudies.reply.util.themeColor
 import com.materialstudies.reply.util.themeInterpolator
 import kotlin.LazyThreadSafetyMode.NONE
 
@@ -94,18 +95,12 @@ class EmailFragment : Fragment() {
 
         sharedElementEnterTransition = MaterialContainerTransform().apply {
             // Scope the transition to a view in the hierarchy so we know it will be added under
-            // the bottom app bar but over the Hold transition from the exiting HomeFragment.
+            // the bottom app bar but over the elevation scale of the exiting HomeFragment.
             drawingViewId = R.id.nav_host_fragment
             duration = resources.getInteger(R.integer.reply_motion_duration_large).toLong()
             interpolator = requireContext().themeInterpolator(R.attr.motionInterpolatorPersistent)
             scrimColor = Color.TRANSPARENT
-        }
-        sharedElementReturnTransition = MaterialContainerTransform().apply {
-            // Again, scope the return transition so it is added below the bottom app bar.
-            drawingViewId = R.id.home_root
-            duration = resources.getInteger(R.integer.reply_motion_duration_large).toLong()
-            interpolator = requireContext().themeInterpolator(R.attr.motionInterpolatorPersistent)
-            scrimColor = Color.TRANSPARENT
+            setAllContainerColors(requireContext().themeColor(R.attr.colorSurface))
         }
     }
 

--- a/Reply/app/src/main/res/layout/fragment_home.xml
+++ b/Reply/app/src/main/res/layout/fragment_home.xml
@@ -15,26 +15,17 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <!-- Add a wrapper layout so we can run return transitions independent of any reenter
-         transitions that may be running on the RecyclerView. -->
-    <FrameLayout
-        android:id="@+id/home_root"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:clipToPadding="false"
-            android:paddingTop="@dimen/grid_0_25"
-            android:paddingBottom="@dimen/bottom_app_bar_height"
-            android:transitionGroup="true"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"
-            app:paddingTopSystemWindowInsets="@{true}"
-            app:paddingBottomSystemWindowInsets="@{true}"/>
-
-    </FrameLayout>
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:paddingTop="@dimen/grid_0_25"
+        android:paddingBottom="@dimen/bottom_app_bar_height"
+        android:transitionGroup="true"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        app:paddingTopSystemWindowInsets="@{true}"
+        app:paddingBottomSystemWindowInsets="@{true}"/>
 
 </layout>


### PR DESCRIPTION
- Adds surface container colors to email transform which prevents home screen content from bleeding through
- Reinforces effect of compose FAB color changing to surface
- Removes `MaterialContainerTransform` `sharedElementReturnTransition` from `EmailFragment` since it is now the same as the enter transition and will be auto-reversed

![reply-container-colors](https://user-images.githubusercontent.com/1420597/84811093-590d5a00-afda-11ea-8497-921d50e979b7.gif)
