### PR TITLE
[Reply] Restructure MenuBottomSheetDialogFragment with a default empt…

### DIFF
--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -40,14 +40,7 @@ import com.materialstudies.reply.ui.compose.ComposeFragmentDirections
 import com.materialstudies.reply.ui.email.EmailFragmentArgs
 import com.materialstudies.reply.ui.home.HomeFragmentDirections
 import com.materialstudies.reply.ui.home.Mailbox
-import com.materialstudies.reply.ui.nav.AlphaSlideAction
-import com.materialstudies.reply.ui.nav.BottomNavDrawerFragment
-import com.materialstudies.reply.ui.nav.ChangeSettingsMenuStateAction
-import com.materialstudies.reply.ui.nav.HalfClockwiseRotateSlideAction
-import com.materialstudies.reply.ui.nav.HalfCounterClockwiseRotateSlideAction
-import com.materialstudies.reply.ui.nav.NavigationAdapter
-import com.materialstudies.reply.ui.nav.NavigationModelItem
-import com.materialstudies.reply.ui.nav.ShowHideFabStateAction
+import com.materialstudies.reply.ui.nav.*
 import com.materialstudies.reply.ui.search.SearchFragmentDirections
 import com.materialstudies.reply.util.contentView
 import kotlin.LazyThreadSafetyMode.NONE
@@ -258,9 +251,9 @@ class MainActivity : AppCompatActivity(),
     }
 
     private fun showDarkThemeMenu() {
-        MenuBottomSheetDialogFragment(R.menu.dark_theme_bottom_sheet_menu) {
-            onDarkThemeMenuItemSelected(it.itemId)
-        }.show(supportFragmentManager, null)
+        MenuBottomSheetDialogFragment
+            .newInstance(R.menu.dark_theme_bottom_sheet_menu)
+            .show(supportFragmentManager, null)
     }
 
     fun navigateToHome(@StringRes titleRes: Int, mailbox: Mailbox) {

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -40,7 +40,14 @@ import com.materialstudies.reply.ui.compose.ComposeFragmentDirections
 import com.materialstudies.reply.ui.email.EmailFragmentArgs
 import com.materialstudies.reply.ui.home.HomeFragmentDirections
 import com.materialstudies.reply.ui.home.Mailbox
-import com.materialstudies.reply.ui.nav.*
+import com.materialstudies.reply.ui.nav.AlphaSlideAction
+import com.materialstudies.reply.ui.nav.BottomNavDrawerFragment
+import com.materialstudies.reply.ui.nav.ChangeSettingsMenuStateAction
+import com.materialstudies.reply.ui.nav.HalfClockwiseRotateSlideAction
+import com.materialstudies.reply.ui.nav.HalfCounterClockwiseRotateSlideAction
+import com.materialstudies.reply.ui.nav.NavigationAdapter
+import com.materialstudies.reply.ui.nav.NavigationModelItem
+import com.materialstudies.reply.ui.nav.ShowHideFabStateAction
 import com.materialstudies.reply.ui.search.SearchFragmentDirections
 import com.materialstudies.reply.util.contentView
 import kotlin.LazyThreadSafetyMode.NONE

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MenuBottomSheetDialogFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MenuBottomSheetDialogFragment.kt
@@ -18,19 +18,25 @@ package com.materialstudies.reply.ui
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.MenuRes
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.navigation.NavigationView
 import com.materialstudies.reply.R
 
-class MenuBottomSheetDialogFragment(
-    private val menuRes: Int,
-    private val onNavigationItemSelected: (MenuItem) -> Boolean
-) : BottomSheetDialogFragment() {
+/**
+ * A bottom sheet dialog for displaying a simple list of action items.
+ */
+class MenuBottomSheetDialogFragment: BottomSheetDialogFragment() {
 
     private lateinit var navigationView: NavigationView
+    @MenuRes private var menuResId: Int = 0
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        menuResId = arguments?.getInt(KEY_MENU_RES_ID, 0) ?: 0
+    }
 
     override fun onCreateView(
             inflater: LayoutInflater,
@@ -47,11 +53,24 @@ class MenuBottomSheetDialogFragment(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         navigationView = view.findViewById(R.id.navigation_view)
-        navigationView.inflateMenu(menuRes)
+        navigationView.inflateMenu(menuResId)
         navigationView.setNavigationItemSelectedListener {
-            val consumed = onNavigationItemSelected(it)
-            if (consumed) dismiss()
-            consumed
+            dismiss()
+            true
+        }
+    }
+
+    companion object {
+
+        private const val KEY_MENU_RES_ID = "MenuBottomSheetDialogFragment_menuResId"
+
+        fun newInstance(@MenuRes menuResId: Int): MenuBottomSheetDialogFragment {
+            val fragment = MenuBottomSheetDialogFragment()
+            val bundle = Bundle().apply {
+                putInt(KEY_MENU_RES_ID, menuResId)
+            }
+            fragment.arguments = bundle
+            return fragment
         }
     }
 }

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MenuBottomSheetDialogFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MenuBottomSheetDialogFragment.kt
@@ -28,7 +28,7 @@ import com.materialstudies.reply.R
 /**
  * A bottom sheet dialog for displaying a simple list of action items.
  */
-class MenuBottomSheetDialogFragment: BottomSheetDialogFragment() {
+class MenuBottomSheetDialogFragment : BottomSheetDialogFragment() {
 
     private lateinit var navigationView: NavigationView
     @MenuRes private var menuResId: Int = 0

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/home/HomeFragment.kt
@@ -118,11 +118,9 @@ class HomeFragment : Fragment(), EmailAdapter.EmailAdapterListener {
     }
 
     override fun onEmailLongPressed(email: Email): Boolean {
-        MenuBottomSheetDialogFragment(R.menu.email_bottom_sheet_menu) {
-            // Do nothing.
-            true
-        }.show(parentFragmentManager, null)
-
+        MenuBottomSheetDialogFragment
+                .newInstance(R.menu.email_bottom_sheet_menu)
+                .show(parentFragmentManager, null)
         return true
     }
 


### PR DESCRIPTION
…y constructor.

Configuration changes with MenuBottomSheetDialogFragment open would crash complaining about the lack of a default cosntructor to use for recreation. This upates the dialog to use a bundle and static constructor instead of a class constructor.

Related - https://github.com/material-components/material-components-android-motion-codelab/issues/1