### PR TITLE
Update Owl

### DIFF
--- a/Owl/app/build.gradle
+++ b/Owl/app/build.gradle
@@ -18,46 +18,50 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     defaultConfig {
         applicationId 'com.materialstudies.owl'
         minSdkVersion 23
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName '1.0'
         vectorDrawables.useSupportLibrary = true
     }
+
     dataBinding {
         enabled true
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = "1.8"
     }
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.fragment:fragment:1.2.0-beta02'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0-beta01'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.fragment:fragment-ktx:1.2.5'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.core:core-ktx:1.5.0-alpha04'
+    implementation 'com.google.android.material:material:1.2.1'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation "androidx.navigation:navigation-runtime-ktx:$nav_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation 'androidx.dynamicanimation:dynamicanimation:1.0.0'
 
-    implementation 'com.github.bumptech.glide:glide:4.9.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
 }

--- a/Owl/app/src/main/java/com/materialstudies/owl/ui/lessons/LessonsSheetFragment.kt
+++ b/Owl/app/src/main/java/com/materialstudies/owl/ui/lessons/LessonsSheetFragment.kt
@@ -24,11 +24,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowInsets
 import androidx.activity.addCallback
 import androidx.annotation.ColorInt
 import androidx.annotation.Px
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type
 import androidx.core.view.doOnLayout
 import androidx.core.view.forEach

--- a/Owl/app/src/main/java/com/materialstudies/owl/ui/lessons/LessonsSheetFragment.kt
+++ b/Owl/app/src/main/java/com/materialstudies/owl/ui/lessons/LessonsSheetFragment.kt
@@ -24,9 +24,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowInsets
 import androidx.activity.addCallback
 import androidx.annotation.ColorInt
 import androidx.annotation.Px
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type
 import androidx.core.view.doOnLayout
 import androidx.core.view.forEach
 import androidx.core.view.postDelayed
@@ -148,7 +151,7 @@ class LessonsSheetFragment : Fragment() {
                     }
                 })
                 lessonsSheet.doOnApplyWindowInsets { _, insets, _, _ ->
-                    behavior.peekHeight = peek + insets.systemWindowInsetBottom
+                    behavior.peekHeight = peek + insets.getInsets(Type.navigationBars()).bottom
                 }
             }
             collapsePlaylist.setOnClickListener {

--- a/Owl/build.gradle
+++ b/Owl/build.gradle
@@ -13,14 +13,14 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
-    ext.nav_version = '2.2.0-beta01'
+    ext.kotlin_version = '1.4.10'
+    ext.nav_version = '2.3.1'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
     }

--- a/Owl/gradle.properties
+++ b/Owl/gradle.properties
@@ -15,7 +15,5 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/Owl/gradle/wrapper/gradle-wrapper.properties
+++ b/Owl/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Nov 02 08:45:57 GMT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
- MDC to 1.2.1
- AGP to 4.1.0
- Gradle to 6.5
- Kotlin to 1.4.10
- Fragment, AppCompat, ConstraintLayout & Navigation to latest
- AndroidX Core to 1.5.0-alpha04
- Glide to 4.11.0

Also
- Compile and target SDK are now 30
- Turned off Jetifier (no need for it)
- Migrated to new WindowInsets APIs