### PR TITLE
Fix adaptive back behavior

### DIFF
--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -20,6 +20,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
 import android.widget.ImageButton
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -46,6 +47,7 @@ import com.materialstudies.reply.ui.nav.NavigationAdapter
 import com.materialstudies.reply.ui.nav.NavigationModelItem
 import com.materialstudies.reply.ui.search.SearchFragmentDirections
 import com.materialstudies.reply.util.AdaptiveUtils
+import com.materialstudies.reply.util.AdaptiveUtils.ContentState
 import com.materialstudies.reply.util.AdaptiveUtils.ScreenSize.SMALL
 import com.materialstudies.reply.util.AdaptiveUtils.ScreenSize.MEDIUM
 import com.materialstudies.reply.util.AdaptiveUtils.ScreenSize.LARGE
@@ -72,6 +74,12 @@ class MainActivity : AppCompatActivity(),
                 ?.fragments
                 ?.first()
 
+    private val closeEmailPaneOnBackPressed = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            closeEmailDetailsPane()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         DynamicColors.applyIfAvailable(this)
         // Update the windows background color to be an elevated surface
@@ -81,6 +89,7 @@ class MainActivity : AppCompatActivity(),
 
         setUpNavigationComponentry()
 
+        onBackPressedDispatcher.addCallback(closeEmailPaneOnBackPressed)
         binding.slidingPaneLayout.setSlidingPaneStateListener(
                 object : ReplySlidingPaneLayout.SlidingPaneStateListener {
                     override fun onCanSlideChanged(canSlide: Boolean) {
@@ -89,6 +98,9 @@ class MainActivity : AppCompatActivity(),
                 })
         AdaptiveUtils.updateScreenSize(this)
         lifecycleScope.launch {
+            AdaptiveUtils.contentState.collect {
+                closeEmailPaneOnBackPressed.isEnabled = it == ContentState.SINGLE_PANE
+            }
             AdaptiveUtils.screenSizeState.collect {
                 when (it) {
                     SMALL -> adaptToSmallScreen()

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/MainActivity.kt
@@ -18,6 +18,7 @@ package com.materialstudies.reply.ui
 
 import android.content.res.Configuration
 import android.os.Bundle
+import android.view.View
 import android.widget.ImageButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isGone
@@ -28,6 +29,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
+import androidx.slidingpanelayout.widget.SlidingPaneLayout
 import com.google.android.material.color.DynamicColors
 import com.google.android.material.elevation.SurfaceColors
 import com.google.android.material.transition.MaterialElevationScale
@@ -35,6 +37,7 @@ import com.google.android.material.transition.MaterialFadeThrough
 import com.google.android.material.transition.MaterialSharedAxis
 import com.materialstudies.reply.R
 import com.materialstudies.reply.databinding.ActivityMainBinding
+import com.materialstudies.reply.ui.common.ReplySlidingPaneLayout
 import com.materialstudies.reply.ui.compose.ComposeFragmentDirections
 import com.materialstudies.reply.ui.email.EmailFragmentArgs
 import com.materialstudies.reply.ui.home.HomeFragmentDirections
@@ -78,6 +81,12 @@ class MainActivity : AppCompatActivity(),
 
         setUpNavigationComponentry()
 
+        binding.slidingPaneLayout.setSlidingPaneStateListener(
+                object : ReplySlidingPaneLayout.SlidingPaneStateListener {
+                    override fun onCanSlideChanged(canSlide: Boolean) {
+                        AdaptiveUtils.updateContentState(canSlide)
+                    }
+                })
         AdaptiveUtils.updateScreenSize(this)
         lifecycleScope.launch {
             AdaptiveUtils.screenSizeState.collect {

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/common/ReplySlidingPaneLayout.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/common/ReplySlidingPaneLayout.kt
@@ -1,0 +1,28 @@
+package com.materialstudies.reply.ui.common
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.slidingpanelayout.widget.SlidingPaneLayout
+
+/** A [SlidingPaneLayout] that reports changes in the slidable state of its sliding pane.*/
+class ReplySlidingPaneLayout @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyle: Int = 0
+) : SlidingPaneLayout(context, attrs, defStyle) {
+
+    interface SlidingPaneStateListener {
+        fun onCanSlideChanged(canSlide: Boolean)
+    }
+
+    private var stateListener: SlidingPaneStateListener? = null
+
+    fun setSlidingPaneStateListener(listener: SlidingPaneStateListener?) {
+        stateListener = listener
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        stateListener?.onCanSlideChanged(isSlideable)
+    }
+}

--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/email/EmailFragment.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/email/EmailFragment.kt
@@ -31,6 +31,7 @@ import com.materialstudies.reply.data.EmailStore
 import com.materialstudies.reply.databinding.FragmentEmailBinding
 import com.materialstudies.reply.ui.MainActivity
 import com.materialstudies.reply.util.AdaptiveUtils
+import com.materialstudies.reply.util.AdaptiveUtils.ContentState
 import com.materialstudies.reply.util.AdaptiveUtils.ScreenSize.LARGE
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -72,8 +73,8 @@ class EmailFragment : Fragment() {
         }
 
         lifecycleScope.launch {
-            AdaptiveUtils.screenSizeState.collect { size ->
-                val navIcon = if (size == LARGE || size == XLARGE) {
+            AdaptiveUtils.contentState.collect { state ->
+                val navIcon = if (state == ContentState.DUAL_PANE) {
                     null
                 } else {
                     ContextCompat.getDrawable(requireContext(), R.drawable.ic_arrow_back_protected)

--- a/Reply/app/src/main/java/com/materialstudies/reply/util/AdaptiveUtils.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/util/AdaptiveUtils.kt
@@ -20,10 +20,27 @@ import android.util.DisplayMetrics
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+/**
+ * A utility class for clients who would like to react to changes in adaptive parameters.
+ */
 object AdaptiveUtils {
 
     enum class ScreenSize {
         SMALL, MEDIUM, LARGE, XLARGE
+    }
+
+    enum class ContentState {
+        /**
+         * Single pane describes a state in which only one pane is actively displayed—either the
+         * list pane or the details pane.
+         */
+        SINGLE_PANE,
+
+        /**
+         * Dual pane describes a side-by-side state in which two panes are actively displayed–both
+         * the list and details pane.
+         */
+        DUAL_PANE
     }
 
     private const val SMALL_SCREEN_SIZE_UPPER_THRESHOLD = 700
@@ -31,16 +48,29 @@ object AdaptiveUtils {
     private const val LARGE_SCREEN_SIZE_UPPER_THRESHOLD = 1024
 
     private val _screenSizeState = MutableStateFlow(ScreenSize.SMALL)
+    /** Screen size state reports changes in screen size categories. */
     val screenSizeState: StateFlow<ScreenSize> = _screenSizeState
+
+    private val _contentState = MutableStateFlow(ContentState.SINGLE_PANE)
+    /** Content state reports changes in the layout of the list/detail layout. */
+    val contentState: StateFlow<ContentState> = _contentState
+
+    fun updateContentState(singlePane: Boolean) {
+        val newState = if (singlePane) ContentState.SINGLE_PANE else ContentState.DUAL_PANE
+        if (_contentState.value == newState) return
+        _contentState.value = newState
+    }
 
     fun updateScreenSize(context: Context) {
         val displayMetrics: DisplayMetrics = context.resources.displayMetrics
         val screenWidth = (displayMetrics.widthPixels / displayMetrics.density).toInt()
-        _screenSizeState.value = when {
+        val newState = when {
             screenWidth < SMALL_SCREEN_SIZE_UPPER_THRESHOLD -> ScreenSize.SMALL
             screenWidth in SMALL_SCREEN_SIZE_UPPER_THRESHOLD until MEDIUM_SCREEN_SIZE_UPPER_THRESHOLD -> ScreenSize.MEDIUM
             screenWidth in MEDIUM_SCREEN_SIZE_UPPER_THRESHOLD until LARGE_SCREEN_SIZE_UPPER_THRESHOLD -> ScreenSize.LARGE
             else -> ScreenSize.XLARGE
         }
+        if (_screenSizeState.value == newState) return
+        _screenSizeState.value = newState
     }
 }

--- a/Reply/app/src/main/res/layout/activity_main.xml
+++ b/Reply/app/src/main/res/layout/activity_main.xml
@@ -61,7 +61,7 @@
 
             </FrameLayout>
 
-            <androidx.slidingpanelayout.widget.SlidingPaneLayout
+            <com.materialstudies.reply.ui.common.ReplySlidingPaneLayout
                 android:id="@+id/sliding_pane_layout"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
@@ -86,7 +86,7 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"/>
 
-            </androidx.slidingpanelayout.widget.SlidingPaneLayout>
+            </com.materialstudies.reply.ui.common.ReplySlidingPaneLayout>
 
             <com.google.android.material.bottomnavigation.BottomNavigationView
                 android:id="@+id/bottom_navigation"


### PR DESCRIPTION
• SlidingPaneLayout occasionally moves from being "slidable" at a different point than when the screen size category is updated. This adds a way to listen for when slidingpanelayout goes between single and dual pane layout mode; separating "navigational" layout updates and "content" layout updates.
• Added an "onBackPressedCallback" to dismiss the detail pane layout when system back is triggered instead of the app exiting.