### PR TITLE
Remove card corner rounding

### DIFF
--- a/Reply/app/src/main/java/com/materialstudies/reply/ui/home/EmailViewHolder.kt
+++ b/Reply/app/src/main/java/com/materialstudies/reply/ui/home/EmailViewHolder.kt
@@ -22,7 +22,6 @@ import com.materialstudies.reply.R
 import com.materialstudies.reply.data.Email
 import com.materialstudies.reply.databinding.EmailItemLayoutBinding
 import com.materialstudies.reply.ui.common.EmailAttachmentAdapter
-import kotlin.math.abs
 
 class EmailViewHolder(
     private val binding: EmailItemLayoutBinding,
@@ -34,19 +33,12 @@ class EmailViewHolder(
             = R.layout.email_attachment_preview_item_layout
     }
 
-    private val starredCornerSize =
-        itemView.resources.getDimension(R.dimen.reply_small_component_corner_radius)
-
     override val reboundableView: View = binding.cardView
 
     init {
         binding.run {
             this.listener = listener
             attachmentRecyclerView.adapter = attachmentAdapter
-            /*
-                TODO: Alter animation to not populate corners
-                root.background = EmailSwipeActionDrawable(root.context)
-             */
         }
     }
 
@@ -55,12 +47,6 @@ class EmailViewHolder(
         binding.root.isActivated = email.isStarred
 
         attachmentAdapter.submitList(email.attachments)
-
-        // Setting interpolation here controls whether or not we draw the top left corner as
-        // rounded or squared. Since all other corners are set to 0dp rounded, they are
-        // not affected.
-        val interpolation = if (email.isStarred) 1F else 0F
-        updateCardViewTopLeftCornerSize(interpolation)
 
         binding.executePendingBindings()
     }
@@ -77,11 +63,6 @@ class EmailViewHolder(
 
         val isStarred = binding.email?.isStarred ?: false
 
-        // Animate the top left corner radius of the email card as swipe happens.
-        val interpolation = (currentSwipePercentage / swipeThreshold).coerceIn(0F, 1F)
-        val adjustedInterpolation = abs((if (isStarred) 1F else 0F) - interpolation)
-        updateCardViewTopLeftCornerSize(adjustedInterpolation)
-
         // Start the background animation once the threshold is met.
         val thresholdMet = currentSwipePercentage >= swipeThreshold
         val shouldStar = when {
@@ -96,17 +77,5 @@ class EmailViewHolder(
         val email = binding.email ?: return
         binding.listener?.onEmailStarChanged(email, !email.isStarred)
         email.notifyChange()
-    }
-
-    // We have to update the shape appearance itself to have the MaterialContainerTransform pick up
-    // the correct shape appearance, since it doesn't have access to the MaterialShapeDrawable
-    // interpolation. If you don't need this work around, prefer using MaterialShapeDrawable's
-    // interpolation property, or in the case of MaterialCardView, the progress property.
-    private fun updateCardViewTopLeftCornerSize(interpolation: Float) {
-        binding.cardView.apply {
-            shapeAppearanceModel = shapeAppearanceModel.toBuilder()
-                .setTopLeftCornerSize(interpolation * starredCornerSize)
-                .build()
-        }
     }
 }


### PR DESCRIPTION
• Design no longer includes the rounding of an email's top left corner when an email is starred. This functionality has been removed